### PR TITLE
Add loading, including a spinner, and the default discord background color as while loading.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".dbg"
+        }
+
         release {
             minifyEnabled false
             signingConfig signingConfigs.release

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,13 +10,15 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="true"
         android:supportsRtl="true"
+        android:theme="@style/LoadingTheme"
         tools:targetApi="31"
         >
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:configChanges="orientation|keyboardHidden|screenSize|layoutDirection"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@style/LoadingTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/dev/vendicated/vencord/MainActivity.java
+++ b/app/src/main/java/dev/vendicated/vencord/MainActivity.java
@@ -25,9 +25,6 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        var bar = this.getActionBar();
-        if (bar != null) bar.hide();
-
         setContentView(R.layout.activity_main);
 
         wv = findViewById(R.id.webview);

--- a/app/src/main/java/dev/vendicated/vencord/VWebviewClient.java
+++ b/app/src/main/java/dev/vendicated/vencord/VWebviewClient.java
@@ -1,6 +1,7 @@
 package dev.vendicated.vencord;
 
 import android.graphics.Bitmap;
+import android.view.View;
 import android.webkit.*;
 
 import androidx.annotation.Nullable;
@@ -20,6 +21,12 @@ public class VWebviewClient extends WebViewClient {
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
         view.evaluateJavascript(HttpClient.VencordRuntime, null);
         view.evaluateJavascript(HttpClient.VencordMobileRuntime, null);
+    }
+
+    @Override
+    public void onPageFinished(WebView view, String url) {
+        view.setVisibility(View.VISIBLE);
+        super.onPageFinished(view, url);
     }
 
     @Nullable

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.widget.LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.widget.RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
+    <ProgressBar android:indeterminate="true" android:layout_width="40dp"
+        android:layout_height="40dp" android:layout_centerInParent="true" />
 
     <WebView
         android:id="@+id/webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        />
-</android.widget.LinearLayout>
+        android:visibility="invisible" />
+</android.widget.RelativeLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources><color name="background">#363942</color></resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources><color name="background">#FFFFFF</color></resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="LoadingTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
-        <item name="android:windowBackground">#363942</item>
+        <item name="android:windowBackground">@color/background</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LoadingTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">#363942</item>
+    </style>
+</resources>


### PR DESCRIPTION
This PR adds a spinner as well as the dark discord background when loading.
It also adds `.dbg` as an `applicationIdSuffix` for the debug build, as it is very useful to be able to have a stable and debug build at once.

Before:
![Screenshot 1](https://cdn.discordapp.com/attachments/789157743323643961/1054126779901673582/Screenshot_20221218-150240084.jpg)
![Screenshot 2](https://cdn.discordapp.com/attachments/789157743323643961/1054126780094623755/Screenshot_20221218-150232819.jpg)

After:
![Screenshot 3](https://cdn.discordapp.com/attachments/789157743323643961/1054126507812995112/Screenshot_20221218-150219328.jpg)